### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ name: Lint
 on:
   push:
     paths:
-      - '*.py'
+      - '**.py'
 
 jobs:
   flake8_py3:


### PR DESCRIPTION
Double asterisk should be used to ensure changes are detected at any depth in the source tree. This is inline with what is shown [in the docs](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#onpushpull_requestpaths).