### PR TITLE
Fix handling of multiple letter error codes

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -42,7 +42,7 @@ function parseFlake8Output(output) {
     // Group 3: column number
     // Group 4: error code
     // Group 5: error description
-    let regex = new RegExp(/^(.*?):(\d+):(\d+): (\w\d+) ([\s|\w]*)/);
+    let regex = new RegExp(/^(.*?):(\d+):(\d+): (\w+\d+) ([\s|\w]*)/);
     let errors = output.split('\n');
     let annotations = [];
     for (let i = 0; i < errors.length; i++) {


### PR DESCRIPTION
The flake8 recommendation is to use "3 letters followed by 3 numbers" for the codes for third-party extensions.

Fixes #3